### PR TITLE
Faster RGB swap

### DIFF
--- a/resource_importer_lottie.cpp
+++ b/resource_importer_lottie.cpp
@@ -139,6 +139,9 @@ Error ResourceImporterLottie::import(const String &p_source_file, const String &
 			ptr_pixel_write++;
         }
 
+		free(ptr_pixel_read);
+		free(ptr_pixel_write);
+
 		Ref<Image> img;
 		img.instance();
 		img->create((int)width, (int)height, false, Image::FORMAT_RGBA8, pixels);

--- a/resource_importer_lottie.cpp
+++ b/resource_importer_lottie.cpp
@@ -121,14 +121,24 @@ Error ResourceImporterLottie::import(const String &p_source_file, const String &
 		pixels.resize(buffer_byte_size);
 		PoolByteArray::Write pixel_write = pixels.write();
 		memcpy(pixel_write.ptr(), buffer.ptr(), buffer_byte_size);
-		for (int32_t pixel_i = 0; pixel_i < pixels.size(); pixel_i += 4) {
-			uint8_t r = pixels[pixel_i + 2];
-			uint8_t g = pixels[pixel_i + 1];
-			uint8_t b = pixels[pixel_i + 0];
-			pixel_write[pixel_i + 2] = b;
-			pixel_write[pixel_i + 1] = g;
-			pixel_write[pixel_i + 0] = r;
-		}
+
+		// switching the r and the b channel is done more effectively via pointers
+		// import time was effectively cut in half because of this change
+        uint8_t *ptr_pixel_read = (uint8_t *)pixels.read().ptr();
+        uint8_t *ptr_pixel_write = (uint8_t *)pixel_write.ptr();
+        for (int32_t pixel_i = 0; pixel_i < pixels.size(); pixel_i += 4) {
+            uint8_t b = *ptr_pixel_read++;
+            uint8_t g = *ptr_pixel_read++;
+            uint8_t r = *ptr_pixel_read++;
+
+            *ptr_pixel_write++ = r;
+            *ptr_pixel_write++ = g;
+            *ptr_pixel_write++ = b;
+
+            ptr_pixel_read++;
+            ptr_pixel_write++;
+        }
+
 		Ref<Image> img;
 		img.instance();
 		img->create((int)width, (int)height, false, Image::FORMAT_RGBA8, pixels);

--- a/resource_importer_lottie.cpp
+++ b/resource_importer_lottie.cpp
@@ -124,19 +124,19 @@ Error ResourceImporterLottie::import(const String &p_source_file, const String &
 
 		// switching the r and the b channel is done more effectively via pointers
 		// import time was effectively cut in half because of this change
-        uint8_t *ptr_pixel_read = (uint8_t *)pixels.read().ptr();
-        uint8_t *ptr_pixel_write = (uint8_t *)pixel_write.ptr();
-        for (int32_t pixel_i = 0; pixel_i < pixels.size(); pixel_i += 4) {
-            uint8_t b = *ptr_pixel_read++;
-            uint8_t g = *ptr_pixel_read++;
-            uint8_t r = *ptr_pixel_read++;
+		uint8_t *ptr_pixel_read = (uint8_t *)pixels.read().ptr();
+		uint8_t *ptr_pixel_write = (uint8_t *)pixel_write.ptr();
+		for (int32_t pixel_i = 0; pixel_i < pixels.size(); pixel_i += 4) {
+			uint8_t b = *ptr_pixel_read++;
+			uint8_t g = *ptr_pixel_read++;
+			uint8_t r = *ptr_pixel_read++;
 
-            *ptr_pixel_write++ = r;
-            *ptr_pixel_write++ = g;
-            *ptr_pixel_write++ = b;
+			*ptr_pixel_write++ = r;
+			*ptr_pixel_write++ = g;
+			*ptr_pixel_write++ = b;
 
-            ptr_pixel_read++;
-            ptr_pixel_write++;
+			ptr_pixel_read++;
+			ptr_pixel_write++;
         }
 
 		Ref<Image> img;


### PR DESCRIPTION
Using pointers instead of the array access vastly increases import speed.
In my tests the time was effectively cut in half by this change.

I worked on this change together with @Streamfire
Even tough only my name now shows in the commits, we worked closely together. So kudos to him.